### PR TITLE
Change ES configuration from single node to two nodes

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,22 +30,58 @@ services:
       restart: always
 
 
-    arches_elasticsearch:
-      container_name: elasticsearch7-17_arches
+    arches_elasticsearch_01:
+      container_name: elasticsearch_arches_01
       image: elasticsearch:8.5.3
       volumes:
-        - elasticsearch-data-arches:/usr/share/elasticsearch/data
+        - elasticsearch-data-arches-01:/usr/share/elasticsearch/data
       ports:
         - "${ELASTIC_PORT}:9200"
         - "127.0.0.1:9301:9300"
       environment:
         - TZ=UTC
-        - discovery.type=single-node
+        - node.name=arches_elasticsearch_01
+        - cluster.name=kint_arches_contaniners_elasticsearch
+        - cluster.initial_master_nodes=arches_elasticsearch_01,arches_elasticsearch_02
+        - discovery.seed_hosts=arches_elasticsearch_02
+        # - discovery.type=single-node
         #- "ES_JAVA_OPTS=-Xms${ELASTIC_JVM_OPTS} -Xmx${ELASTIC_JVM_OPTS}"
         - bootstrap.memory_lock=true
         - ELASTIC_USER=$ELASTIC_USER
         - ELASTIC_PASSWORD=$ELASTIC_PASSWORD
-        - xpack.security.enabled=$ELASTIC_SECURITY        
+        - xpack.security.enabled=$ELASTIC_SECURITY
+        - xpack.security.transport.ssl.enabled=$ELASTIC_SECURITY
+      mem_limit: 3g
+      ulimits:
+        memlock:
+          soft: -1
+          hard: -1
+      networks:
+        - arches-network
+      restart: always
+
+
+    arches_elasticsearch_02:
+      container_name: elasticsearch_arches_02
+      image: elasticsearch:8.5.3
+      volumes:
+        - elasticsearch-data-arches-02:/usr/share/elasticsearch/data
+      environment:
+        - TZ=UTC
+        - node.name=arches_elasticsearch_02
+        - cluster.name=kint_arches_contaniners_elasticsearch
+        - cluster.initial_master_nodes=arches_elasticsearch_01,arches_elasticsearch_02
+        - discovery.seed_hosts=arches_elasticsearch_01
+        # - discovery.type=single-node
+        #- "ES_JAVA_OPTS=-Xms${ELASTIC_JVM_OPTS} -Xmx${ELASTIC_JVM_OPTS}"
+        - bootstrap.memory_lock=true
+        - xpack.security.enabled=$ELASTIC_SECURITY 
+        - xpack.security.transport.ssl.enabled=$ELASTIC_SECURITY 
+      mem_limit: {ELASTIC_MEM_LIMIT}
+      ulimits:
+        memlock:
+          soft: -1
+          hard: -1
       networks:
         - arches-network
       restart: always
@@ -135,8 +171,8 @@ volumes:
     couchdb-log-arches:
     postgres-data-arches:
     postgres-log-arches:
-    elasticsearch-data-arches:
-    elasticsearch-upgrade-data-arches:
+    elasticsearch-data-arches-01:
+    elasticsearch-data-arches-02:
     rabbitmq-logs-arches:
     rabbitmq-data-arches:
     geoserver-data-arches:

--- a/env_template
+++ b/env_template
@@ -14,6 +14,7 @@ ELASTIC_PASSWORD=
 ELASTIC_PORT=127.0.0.1:9201 # e.g. 9201 or 127.0.0.1:9201 for localhost
 ELASTIC_JVM_OPTS= # e.g. 8g or 1024m
 ELASTIC_SECURITY= # lowercase true or false
+ELASTIC_MEM_LIMIT= # e.g. 8g or 1024m
 
 # Geoserver config
 GEOSERVER_ADMIN_USER=


### PR DESCRIPTION
As per the Arches docs (https://arches.readthedocs.io/en/stable/developing/getting-started/arches-and-elasticsearch/#using-multiple-nodes) using 2 nodes is recommended in production, even if the normal mem limit is used by splitting across the two nodes.